### PR TITLE
Cached dependencies

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -2,59 +2,60 @@ import * as path from 'path';
 import { workspace, ExtensionContext } from 'vscode';
 
 import {
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	TransportKind
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    TransportKind
 } from 'vscode-languageclient';
 
 let client: LanguageClient;
 
 export function activate(context: ExtensionContext) {
-	// The server is implemented in node
-	let serverModule = context.asAbsolutePath(
-		path.join('server', 'out', 'server.js')
-	);
-	// The debug options for the server
-	// --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
-	let debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
+    // The server is implemented in node
+    const serverModule = context.asAbsolutePath(
+        path.join('server', 'out', 'server.js')
+    );
+    // The debug options for the server
+    // --inspect=6009: runs the server in Node's Inspector mode so VS Code can attach to the server for debugging
+    const debugOptions = { execArgv: ['--nolazy', '--inspect=6009'] };
 
-	// If the extension is launched in debug mode then the debug server options are used
-	// Otherwise the run options are used
-	let serverOptions: ServerOptions = {
-		run: { module: serverModule, transport: TransportKind.ipc },
-		debug: {
-			module: serverModule,
-			transport: TransportKind.ipc,
-			options: debugOptions
-		}
-	};
+    // If the extension is launched in debug mode then the debug server options are used
+    // Otherwise the run options are used
+    const serverOptions: ServerOptions = {
+        run: { module: serverModule, transport: TransportKind.ipc },
+        debug: {
+            module: serverModule,
+            transport: TransportKind.ipc,
+            options: debugOptions
+        }
+    };
 
-	// Options to control the language client
-	let clientOptions: LanguageClientOptions = {
-		// Register the server for c0 documents
-		documentSelector: [{ scheme: 'file', language: 'C0' }],
-		synchronize: {
-			// Notify the server about file changes to '.clientrc files contained in the workspace
-			fileEvents: workspace.createFileSystemWatcher('**/.clientrc')
-		}
-	};
+    // Options to control the language client
+    const clientOptions: LanguageClientOptions = {
+        // Register the server for c0 documents
+        documentSelector: [{ scheme: 'file', language: 'C0' }],
+        synchronize: {
+            // Notify the server about file changes to .c0 or .c1 files, for dependencies
+            fileEvents: [workspace.createFileSystemWatcher('**/*.c0'),
+                         workspace.createFileSystemWatcher('**/*.c1')]
+        }
+    };
 
-	// Create the language client and start the client.
-	client = new LanguageClient(
-		'c0LanguageServer',
-		'C0 Language Server',
-		serverOptions,
-		clientOptions
-	);
+    // Create the language client and start the client.
+    client = new LanguageClient(
+        'c0LanguageServer',
+        'C0 Language Server',
+        serverOptions,
+        clientOptions
+    );
 
-	// Start the client. This will also launch the server
-	client.start();
+    // Start the client. This will also launch the server
+    client.start();
 }
 
 export function deactivate(): Thenable<void> | undefined {
-	if (!client) {
-		return undefined;
-	}
-	return client.stop();
+    if (!client) {
+        return undefined;
+    }
+    return client.stop();
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -37,7 +37,8 @@ export function activate(context: ExtensionContext) {
         synchronize: {
             // Notify the server about file changes to .c0 or .c1 files, for dependencies
             fileEvents: [workspace.createFileSystemWatcher('**/*.c0'),
-                         workspace.createFileSystemWatcher('**/*.c1')]
+                         workspace.createFileSystemWatcher('**/*.c1'),
+                         workspace.createFileSystemWatcher('**/project.txt')]
         }
     };
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -62,7 +62,7 @@ connection.onInitialize((params: InitializeParams) => {
   };
 });
 
-connection.onInitialized(async () => {
+connection.onInitialized(() => {
   if (hasWorkspaceFolderCapability) {
     connection.workspace.onDidChangeWorkspaceFolders(event => {
       connection.console.log('Workspace folder change event received.');

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -15,7 +15,8 @@ import {
   LocationLink,
   CompletionParams,
   Range,
-  Position
+  Position,
+  FileChangeType
 } from 'vscode-languageserver';
 
 import { basicLexing } from './lex';
@@ -123,12 +124,18 @@ connection.onDidChangeWatchedFiles(async params => {
     invalidate(change.uri);
 
     if (change.uri.endsWith('/project.txt')) {
-      // Invalidate all references to this project.txt
-      cachedProject.forEach((value, key) => {
-        if (value.uri === change.uri) {
-          cachedProject.delete(key);
-        }
-      });
+      if (change.type === FileChangeType.Created) {
+        // Invalidate all project.txt caches, since this may be a new project file
+        cachedProject.clear();
+      } else {
+        // Invalidate all references to this project.txt
+        cachedProject.forEach((value, key) => {
+          if (value.uri === change.uri) {
+            cachedProject.delete(key);
+          }
+        });
+      }
+
       // Ordering of files may have changed, screwing dependencies.
       invalidateAll();
     }
@@ -153,7 +160,7 @@ documents.onDidChangeContent(async change => {
 
     const maybeDependencies = getDependencies(change.document.uri, [
       `${dir}/project.txt`,
-      `${dir}/../project.txt`, // Look one folder above 
+      `${dir}/../project.txt`, // Look one folder above
       folders && folders.length ? `${folders[0].uri}/project.txt` : ""
     ].map(p => new URL(p)));
 
@@ -187,7 +194,7 @@ function mkCodeString(s: string): string {
   return `\`\`\`c0\n${s}\n\`\`\``;
 }
 
-/** 
+/**
  * Turns a string with C0 code into a MarkupContent object,
  * which can be sent as part of various LSP responses
  */
@@ -203,7 +210,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
   // TODO: use completionInfo to figure out if we should add keywords or not
 
   // The pass parameter contains the position of the text document in
-  // which code complete got requested. 
+  // which code complete got requested.
   const keywords: CompletionItem[] =
     basicLexing.identifier.keywords.keyword.map(word => ({
       label: word,
@@ -221,12 +228,12 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
   const locals: CompletionItem[] = [];
   const fieldNames: CompletionItem[] = [];
 
-  // TODO: only show decls up to this point 
+  // TODO: only show decls up to this point
   for (const decl of decls.decls) {
-    // Stop once we get to a decl after the curser position 
+    // Stop once we get to a decl after the curser position
     // in the current file
-    if (decl.loc && decl.loc.source === completionInfo.textDocument.uri 
-        && comparePositions(pos, decl.loc?.start) === Ordering.Less) 
+    if (decl.loc && decl.loc.source === completionInfo.textDocument.uri
+        && comparePositions(pos, decl.loc?.start) === Ordering.Less)
       break;
 
     switch (decl.tag) {
@@ -235,7 +242,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
           label: decl.definition.id.name,
           kind: CompletionItemKind.Interface,
           documentation: mkMarkdownCode(`typedef ${typeToString(decl.definition.kind)} ${decl.definition.id.name}`),
-          detail: decl.loc?.source || undefined 
+          detail: decl.loc?.source || undefined
         });
         break;
 
@@ -244,7 +251,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
           label: decl.definition.id.name,
           kind: CompletionItemKind.Interface,
           documentation: mkMarkdownCode(`typedef ${typeToString({ tag: "FunctionType", definition: decl.definition })}`),
-          detail: decl.loc?.source || undefined 
+          detail: decl.loc?.source || undefined
         });
         break;
 
@@ -255,7 +262,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
             label: field.id.name,
             kind: CompletionItemKind.Field,
             documentation: mkMarkdownCode(`${typeToString(field.kind)} ${decl.id.name}::${field.id.name}`),
-            detail: decl.loc?.source || undefined 
+            detail: decl.loc?.source || undefined
           });
         }
         break;
@@ -263,7 +270,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
       case "FunctionDeclaration": {
         // Prefer to use contracts from a function definition
         if (decl.body || !functionDecls.has(decl.id.name)) {
-          const requires = decl.preconditions.map(precond => 
+          const requires = decl.preconditions.map(precond =>
               `//@requires ${expressionToString(precond)}`);
           const ensures = decl.postconditions.map(postcond =>
               `//@ensures ${expressionToString(postcond)}`);
@@ -277,7 +284,7 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
           });
         }
         if (decl.body) {
-          // Look in the function body for local variables 
+          // Look in the function body for local variables
           if (!isInside(pos, decl.body.loc)) break;
 
           const searchResult = findStatement(decl.body, null, { pos, genv: decls });
@@ -297,10 +304,10 @@ connection.onCompletion((completionInfo: CompletionParams): CompletionItem[] => 
     }
   }
 
-  // Don't include keywords since that corrupts the list 
+  // Don't include keywords since that corrupts the list
   // FIXME: we can just use "sortText" to move them
   // to the end of the completion list. But we then
-  // have to implement sortText for everything it seems 
+  // have to implement sortText for everything it seems
 
   const completions = [...locals, ...functionDecls.values(), ...typedefs, ...fieldNames];
 
@@ -313,12 +320,12 @@ connection.onCompletionResolve((item: CompletionItem): CompletionItem => item);
 
 connection.onHover((data: TextDocumentPositionParams): Hover | null => {
   const genv = openFiles.get(data.textDocument.uri);
-  // Indicates no successful parse so far 
+  // Indicates no successful parse so far
   if (genv === undefined) { return null; }
 
   // Note that VSCode 0-indexes positions,
   // so to be compatible with nearley we must
-  // add 1 
+  // add 1
   const hoverPos: ast.Position = ast.fromVscodePosition(data.position);
 
   // Search for which function we are in now
@@ -328,7 +335,7 @@ connection.onHover((data: TextDocumentPositionParams): Hover | null => {
   const searchResult = findGenv({ pos: hoverPos, genv: genv }, data.textDocument.uri);
 
   // This indicates that the user hovered over something that
-  // wasn't an indentifier 
+  // wasn't an indentifier
   if (searchResult === null || searchResult.data === null) return null;
 
   switch (searchResult.data.tag) {
@@ -366,7 +373,7 @@ connection.onDefinition((data: TextDocumentPositionParams): LocationLink[] | nul
   }
 
   const genv = openFiles.get(data.textDocument.uri);
-  // Indicates no successful parse so far 
+  // Indicates no successful parse so far
   if (genv === undefined) { return null; }
 
   const pos: ast.Position = ast.fromVscodePosition(data.position);
@@ -374,7 +381,7 @@ connection.onDefinition((data: TextDocumentPositionParams): LocationLink[] | nul
   const searchResult = findGenv({ pos, genv }, data.textDocument.uri);
 
   // This indicates that the user hovered over something that
-  // wasn't an indentifier 
+  // wasn't an indentifier
   if (searchResult === null || searchResult.data === null) return null;
 
   switch (searchResult.data.tag) {
@@ -383,7 +390,7 @@ connection.onDefinition((data: TextDocumentPositionParams): LocationLink[] | nul
 
       switch (type.tag) {
         case "Identifier":
-          // Find a typedef with this tag 
+          // Find a typedef with this tag
           const typedef = getTypedefDefinition(genv, type.name);
           if (typedef !== null && typedef.loc) {
             return toLocationLink(typedef.loc);
@@ -404,7 +411,7 @@ connection.onDefinition((data: TextDocumentPositionParams): LocationLink[] | nul
 
       if (type.tag === "FunctionType") {
         // Look up function
-        // TODO: suggest both the function declaration and the function definition 
+        // TODO: suggest both the function declaration and the function definition
         const func = getFunctionDeclaration(genv, name);
         if (func && func.loc) {
           return toLocationLink(func.loc);

--- a/server/src/typecheck/globalenv.ts
+++ b/server/src/typecheck/globalenv.ts
@@ -68,6 +68,16 @@ export function initEmpty(): GlobalEnv {
     };
 }
 
+export function cloneGenv(genv: GlobalEnv): GlobalEnv {
+    return {
+        libstructs: new Set(genv.libstructs),
+        libfuncs: new Set(genv.libfuncs),
+        libsLoaded: new Set(genv.libsLoaded),
+        filesLoaded: new Set(genv.filesLoaded),
+        decls: []
+    }
+}
+
 /**
  * Create an initial GlobalEnv with the correct type for main()
  */

--- a/server/src/validate-program.ts
+++ b/server/src/validate-program.ts
@@ -38,6 +38,10 @@ type FileCache = {
  */
 const cachedFiles = new Map<string, FileCache>();
 
+/**
+ * Invalidates a file in the cache
+ * @param file the URI of the file to invalidate
+ */
 export function invalidate(file: string) {
   const cache = cachedFiles.get(file);
   if (cache) {
@@ -46,6 +50,9 @@ export function invalidate(file: string) {
   }
 }
 
+/**
+ * Invalidates all files in the cache.
+ */
 export function invalidateAll() {
   cachedFiles.clear();
 }


### PR DESCRIPTION
All dependencies are cached now, resolving #15. In addition, project.txt should be cached. It uses LSP built-in client file watching, which then notifies the server to invalidate dependencies.