### PR TITLE
Change 0x colors to match numeric literal and change type colors

### DIFF
--- a/themes/C0-dark.color-theme.json
+++ b/themes/C0-dark.color-theme.json
@@ -84,7 +84,7 @@
 			"name": "Units (i.e. 0x in 0xFF)",
 			"scope": "keyword.other.unit",
 			"settings": {
-				"foreground": "#b5cea8"
+				"foreground": "#71deff"
 			}
         },
         {
@@ -195,7 +195,7 @@
 				"storage.modifier"
 			],
 			"settings": {
-				"foreground": "#ec7ebb"
+				"foreground": "#FF7F50"
 			}
 		},
 		{


### PR DESCRIPTION
Iliano mentioned that the colors for keywords like (`return`, `alloc`, `if`) are the same as the color for types (`int`, `string`, `bool`). I tried changing it but I don't know if the color is good. 

I also changed the color for the leading 0x to match with the rest of the number. Feel free to revert it if you don't agree 