### PR TITLE
Document Formatting

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,9 @@ import {
   TextDocumentChangeEvent,
   ParameterInformation,
   SignatureInformation,
-  WorkspaceFolder
+  WorkspaceFolder,
+  DocumentFormattingParams,
+  TextEdit
 } from 'vscode-languageserver';
 
 import { basicLexing } from './lex';
@@ -63,7 +65,8 @@ connection.onInitialize((params: InitializeParams) => {
       },
       hoverProvider: true,
       definitionProvider: true,
-      signatureHelpProvider: { triggerCharacters: ["(", ","] }
+      signatureHelpProvider: { triggerCharacters: ["(", ","] },
+      documentFormattingProvider: true
     }
   };
 });
@@ -619,6 +622,33 @@ connection.onSignatureHelp((data) => {
       activeParameter: context.argumentNumber
     };
   }
+});
+
+connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | null => {
+  const doc = documents.get(data.textDocument.uri);
+  if (!doc) return null;
+
+  let indentLevel = 0;
+  const indentChar = data.options.insertSpaces ? ' '.repeat(data.options.tabSize) : '\t';
+  const edits: TextEdit[] = [];
+  for (const [lineNum, line] of doc.getText().split("\n").entries()) {
+      const lineLen = line.length;
+      const trimmedLine = line.trim();
+      if (trimmedLine.startsWith("}")) {
+          --indentLevel;
+      }
+      edits.push({
+          range: { 
+              start: { line: lineNum, character: 0 }, 
+              end: { line: lineNum, character: lineLen }
+          },
+          newText: `${indentChar.repeat(indentLevel)}${trimmedLine}`
+      });
+      if (trimmedLine.endsWith("{")) {
+          ++indentLevel;
+      }
+  }
+  return edits;
 });
 
 // Make the text document manager listen on the connection


### PR DESCRIPTION
This pull request is to support the `textDocument/formatting` method. Currently it does so based on naive brace matching (which leads to some minor issues).

TODO:
- [x] Improve handling of multiline comments
- [ ] Switch to using ASTs instead of just reading source directly
- [ ] Maintain indentation of conditionals, function calls, etc... broken across multiple lines

---
Closes #29 
