### PR TITLE
Simple Indentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 .vscode-test/
 *.vsix
 .DS_Store
+.lvimrc
 # Generated parser 
 server/src/expression-rules.ts
 server/src/program-rules.ts

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -743,6 +743,8 @@ connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | n
     let seenFirstOpen = false;
     inString = false;
     inCharLit = false;
+    const ignoreLine = line.trimLeft().startsWith("//") || inComment;
+    if (!ignoreLine) {
     for (let i = 0; i < line.length; ++i) {
       const char = line.charAt(i);
 
@@ -770,6 +772,7 @@ connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | n
       }
     }
     indentLevel -= closesBeforeFirstOpen;
+    }
 
     edits.push(TextEdit.replace(
       Range.create(
@@ -778,7 +781,9 @@ connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | n
       ),
       `${inComment ? ' ' : ''}${indentChar.repeat(indentLevel < 0 ? 0 : indentLevel)}${line.trim()}`,
     ));
-    indentLevel += opens - closes + closesBeforeFirstOpen;
+    if (!ignoreLine) {
+      indentLevel += opens - closes + closesBeforeFirstOpen;
+    }
 
     if (line.includes("/*") && !line.includes("*/")) {
       inComment = true;

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -703,7 +703,7 @@ connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | n
   for (const [lineNum, line] of doc.getText().split("\n").entries()) {
     const lineLen = line.length;
     const closes = (line.match(/(\)|})/g) || []).length;
-    const opens = (line.match(/(\)|{)/g) || []).length;
+    const opens = (line.match(/(\(|{)/g) || []).length;
     let closesBeforeFirstOpen = 0;
     for (let i = 0;
       i < line.length && line.charAt(i) !== '(' && line.charAt(i) !== '{';

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -18,7 +18,9 @@ import {
   TextDocumentChangeEvent,
   ParameterInformation,
   SignatureInformation,
-  WorkspaceFolder
+  WorkspaceFolder,
+  DocumentFormattingParams,
+  TextEdit
 } from 'vscode-languageserver';
 
 import { basicLexing } from './lex';
@@ -63,7 +65,8 @@ connection.onInitialize((params: InitializeParams) => {
       },
       hoverProvider: true,
       definitionProvider: true,
-      signatureHelpProvider: { triggerCharacters: ["(", ","] }
+      signatureHelpProvider: { triggerCharacters: ["(", ","] },
+      documentFormattingProvider: true
     }
   };
 });
@@ -619,6 +622,33 @@ connection.onSignatureHelp((data) => {
       activeParameter: context.argumentNumber
     };
   }
+});
+
+connection.onDocumentFormatting((data: DocumentFormattingParams): TextEdit[] | null => {
+  const doc = documents.get(data.textDocument.uri);
+  if (!doc) return null;
+
+  let indentLevel = 0;
+  const indentChar = data.options.insertSpaces ? ' '.repeat(data.options.tabSize) : '\t';
+  const edits: TextEdit[] = [];
+  for (const [lineNum, line] of doc.getText().split("\n").entries()) {
+      const lineLen = line.length;
+      const trimmedLine = line.trim();
+      if (trimmedLine.startsWith("}")) {
+          --indentLevel;
+      }
+      edits.push({
+          range: { 
+              start: { line: lineNum, character: 0 }, 
+              end: { line: lineNum, character: lineLen }
+          },
+          newText: `${indentChar.repeat(indentLevel)}${trimmedLine}`
+      });
+      if (trimmedLine.endsWith("{")) {
+          ++indentLevel;
+      }
+  }
+  return edits;
 });
 
 // Make the text document manager listen on the connection


### PR DESCRIPTION
As a temporary measure before #33 (specifically, whole AST based document formatting) is finalized this provides for fairly basic whole document (re)indentation within blocks enclosed by `{ }`, i.e., block statements, and `( )`, with a typical use case of multi-line function calls.